### PR TITLE
Changed to not run cron process as PID 1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ COPY package-lock.json ./package-lock.json
 RUN npm install
 
 FROM node:8.14.0-alpine
+RUN apk add --no-cache tini
+ENTRYPOINT ["/sbin/tini", "--"]
 
 COPY --from=basis /opt/cron /opt/cron
 WORKDIR /opt/cron


### PR DESCRIPTION
PID 1 has a special purpose and system signals work
different for it. The solution is to use tini,
which is an 'init' process.