### PR TITLE
Added a handler to terminate the process for unhandled promise events

### DIFF
--- a/server.js
+++ b/server.js
@@ -7,11 +7,16 @@ const logger = require("@dojot/dojot-module-logger").logger;
 
 logger.setLevel("info");
 
+process.on('unhandledRejection', (reason, _promise) => {
+    logger.error(`Unhandled Rejection at: ${reason.stack || reason}. Bailing out!!`);
+    process.kill(process.pid, "SIGTERM");
+});
+
 var cronManager = new cron.CronManager();
 cronManager.init().then(() => {
     healthcheck.init(cronManager);
     api.init(cronManager, healthcheck.get());
 }).catch(error => {
     logger.error(`Cron service initialization failed (${error}). Bailing out!!`);
-    process.exit(-1);
+    process.kill(process.pid, "SIGTERM");
 });

--- a/server.js
+++ b/server.js
@@ -7,7 +7,7 @@ const logger = require("@dojot/dojot-module-logger").logger;
 
 logger.setLevel("info");
 
-process.on('unhandledRejection', (reason, _promise) => {
+process.on('unhandledRejection', (reason) => {
     logger.error(`Unhandled Rejection at: ${reason.stack || reason}. Bailing out!!`);
     process.kill(process.pid, "SIGTERM");
 });


### PR DESCRIPTION
In Node 8, a unhandled promise event doesn't cause a crash, but
this condition is a bug and might be critical. So, this change
forces the process to terminate.